### PR TITLE
[WIP] Support running todoapp on docker-compose

### DIFF
--- a/todoapp_v0/README.md
+++ b/todoapp_v0/README.md
@@ -15,6 +15,20 @@ mysql> grant all on todoapp.* to todouser;
 - ToDoV1.war を手元のPCの tomcatの webappsにコピー
 - ブラウザから，http://localhost:8080/ToDoV1/ にアクセス
 
+### :whale: `docker-compose`での実行
+
+* 起動
+    * `docker-compose up -d`
+        * `-d` を付けるとバックグラウンドで実行．
+        * `docker-compose logs -f` でバックグラウンドで出力されるログを確認できる．
+* 終了
+    * `docker-compose stop` で終了．
+    * `docker-compose down` でコンテナも削除する．
+* `docker-compose` で起動している `mysql` に接続する．
+    * `docker exec -it todo_mysql bash`
+        * `todo_mysql` というコンテナ上で `bash` を起動する（`-it`はインタラクティブモード）．
+    * その後，`bash`上で `mysql -u todouser -p` で接続する．
+
 ## 設計
 - メンバー，および，ToDo項目をCRUDする典型的なアプリケーション
 - フロントエンド： Thymeleafでサーバ側で生成

--- a/todoapp_v0/docker-compose.yml
+++ b/todoapp_v0/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3"
+services:
+  todoapp:
+    image: tomcat:9-jdk11-corretto
+    container_name: tomcat_todoapp
+    ports:
+      - 8080:8080
+    volumes: # ホストOSのディレクトリ:コンテナOSでのマウント先
+      - ./build/libs:/usr/local/tomcat/webapps
+    environment: # Docker-compose で起動した時の接続先．application.propertiesも参照のこと．
+      DATASTORE: jdbc:mysql://db:3306/todoapp
+  db:
+    image: mysql:8.0
+    container_name: todo_mysql
+    restart: always
+    ports: # ホストOSのポート番号:コンテナOSのポート番号
+      - 13306:3306
+      # ホストOSで mysql を起動しっぱなしにしておくため，ポート番号を分ける．
+      # 上の DATASTORE のポート番号は db のポート番号であるため，3306 で良い．
+    volumes:
+      - ./build/mysql/data:/var/lib/mysql                  # データ置き場
+      - ./src/docker/mysql/my.cnf:/etc/mysql/conf.d/my.cnf # 設定ファイル
+    environment:
+      MYSQL_ROOT_PASSWORD: 'rootroot'
+      MYSQL_DATABASE: 'todoapp'
+      MYSQL_USER: 'todouser'
+      MYSQL_PASSWORD: 'todotodo'
+      TZ: 'Asia/Tokyo'
+

--- a/todoapp_v0/src/docker/mysql/my.cnf
+++ b/todoapp_v0/src/docker/mysql/my.cnf
@@ -1,0 +1,8 @@
+[mysqld]
+character-set-server=utf8
+
+[mysql]
+default-character-set=utf8
+
+[client]
+default-character-set=utf8

--- a/todoapp_v0/src/main/resources/application.properties
+++ b/todoapp_v0/src/main/resources/application.properties
@@ -2,9 +2,11 @@
 server.port = 18080
 
 # MySQLデータベース接続設定
-spring.datasource.url=jdbc:mysql://localhost:3306/todoapp
 spring.datasource.username=todouser
 spring.datasource.password=todotodo
+## ${環境変数名:デフォルト値} で，ローカルで起動した場合（テスト時），
+## Docker経由で起動した場合の接続先をそれぞれ設定する．
+spring.datasource.url=${DATASTORE:jdbc:mysql://localhost:3306/todoapp}
 
 # Spring-JPA: DBのテーブルを自動作成してくれる機能
 # create: 新規作成， update: なければ新規作成， create-drop: 新規作成し終了時に削除


### PR DESCRIPTION
docker-compose.yml と Docker 上での MySQL の設定ファイルを追加した．
docker-compose 上で SpringBoot が起動された場合とローカルで起動された場合で，
MySQL の接続先が異なってくるので，接続先を切り替えるよう，application.properties も修正した．

基本的に，プロジェクトのトップページ（`docker-compose.yml`のあるディレクトリ）で，`docker-compose up` を実行してしばらく待つと `http://localhost:8080/ToDoV0/` にアクセスできるようになります．
（Tomcatは重複して実行できないかも）

### 参考資料

* [DockerでMySQLを使ってみる](https://qiita.com/TAMIYAN/items/ed9ec892d91e5af962c6)
* [docker-composeでspring-boot+mysqlのアプリケーションを起動](https://qiita.com/yamii/items/b2b5e6b6a7aff6d590d8)
* [Dockerを使って簡単にローカルtomcat環境を作る](https://qiita.com/hikaruright/items/f8095f4610b289a86144)
* [application.propertiesの設定を環境変数を用いてlocal起動とDocker起動で切り替える](https://qiita.com/SSM3G/items/40bac2fc47c6b80884e8)
* [[Docker] Windows 10 Pro 64bit に Docker と Docker Compose をインストールする](https://qiita.com/ksh-fthr/items/6b1242c010fac7395a45)